### PR TITLE
chore: Prepare release automation

### DIFF
--- a/.actionspanel/buttons.yml
+++ b/.actionspanel/buttons.yml
@@ -1,0 +1,4 @@
+buttons:
+  - title: Release cloudwaste
+    action: "release"
+    description: Release a new version of cloudwaste

--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -1,0 +1,12 @@
+version: 1
+update_configs:
+  - package_manager: "go:modules"
+    directory: "/"
+    update_schedule: "daily"
+    commit_message:
+      prefix: "chore"
+      include_scope: true
+    automerged_updates:
+      - match:
+          dependency_type: "all"
+          update_type: "all"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,24 @@
+name: Release Actions Panel
+on:
+  repository_dispatch:
+    types: [release]
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+      - uses: actions/setup-go@v1
+        with:
+          go-version: "1.14"
+      - name: Generate release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: npx semantic-release
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v1
+        with:
+          version: latest
+          args: release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,20 @@
+env:
+  - CGO_ENABLED=0
+archives:
+  - replacements:
+      darwin: mac
+      linux: linux
+      windows: win64
+    format_overrides:
+      - goos: windows
+        format: zip
+builds:
+  - goos:
+      - linux
+      - darwin
+      - windows
+    goarch:
+      - amd64
+    main: ./cmd/main.go
+    binary: cloudwaste
+    id: "build-cloudwaste"

--- a/.releaserc
+++ b/.releaserc
@@ -1,0 +1,7 @@
+{
+  "plugins": [
+    "@semantic-release/commit-analyzer",
+    "@semantic-release/release-notes-generator",
+    "@semantic-release/github"
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -1,7 +1,12 @@
 ![cloud waste](/docs/cloudwaste.svg)
 > Find pure waste in your cloud accounts
 
+[![Actions Panel](https://img.shields.io/badge/actionspanel-enabled-brightgreen)](https://www.actionspanel.app/app/phunki/actionspanel)
 [![codecov](https://codecov.io/gh/timmyers/cloudwaste/branch/master/graph/badge.svg)](https://codecov.io/gh/timmyers/cloudwaste)
+[![Test](https://github.com/timmyers/cloudwaste/workflows/Test/badge.svg)](https://github.com/timmyers/cloudwaste/actions?query=workflow%3ATest)
+[![release](https://img.shields.io/github/release/phunki/actionspanel.svg)](https://github.com/phunki/actionspanel/releases/latest)
+[![GitHub release date](https://img.shields.io/github/release-date/phunki/actionspanel.svg)](https://github.com/phunki/actionspanel/releases)
+[![Dependabot Status](https://api.dependabot.com/badges/status?host=github&repo=phunki/actionspanel)](https://dependabot.com)
 
 # Getting started
 `go run main.go run`

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 ![cloud waste](/docs/cloudwaste.svg)
 > Find pure waste in your cloud accounts
 
-[![Actions Panel](https://img.shields.io/badge/actionspanel-enabled-brightgreen)](https://www.actionspanel.app/app/phunki/actionspanel)
+[![Actions Panel](https://img.shields.io/badge/actionspanel-enabled-brightgreen)](https://www.actionspanel.app/app/timmyers/cloudwaste)
 [![codecov](https://codecov.io/gh/timmyers/cloudwaste/branch/master/graph/badge.svg)](https://codecov.io/gh/timmyers/cloudwaste)
 [![Test](https://github.com/timmyers/cloudwaste/workflows/Test/badge.svg)](https://github.com/timmyers/cloudwaste/actions?query=workflow%3ATest)
-[![release](https://img.shields.io/github/release/phunki/actionspanel.svg)](https://github.com/phunki/actionspanel/releases/latest)
-[![GitHub release date](https://img.shields.io/github/release-date/phunki/actionspanel.svg)](https://github.com/phunki/actionspanel/releases)
-[![Dependabot Status](https://api.dependabot.com/badges/status?host=github&repo=phunki/actionspanel)](https://dependabot.com)
+[![release](https://img.shields.io/github/release/timmyers/cloudwaste.svg)](https://github.com/timmyers/cloudwaste/releases/latest)
+[![GitHub release date](https://img.shields.io/github/release-date/timmyers/cloudwaste.svg)](https://github.com/timmyers/cloudwaste/releases)
+[![Dependabot Status](https://api.dependabot.com/badges/status?host=github&repo=timmyers/cloudwaste)](https://dependabot.com)
 
 # Getting started
 `go run main.go run`


### PR DESCRIPTION
This commit mainly configures a workflow for semantic-release and
goreleaser to build and attach OS specific binaries to the release.
Creating releases is triggered through a button on ActionsPanel.

We've also added dependabot for keeping dependencies up to date.