### PR TITLE
chore: Correct main.go path

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -15,6 +15,6 @@ builds:
       - windows
     goarch:
       - amd64
-    main: ./cmd/main.go
+    main: ./main.go
     binary: cloudwaste
     id: "build-cloudwaste"


### PR DESCRIPTION
The path was pointing to somewhere in `cmd` instead of `main.go` at the root.